### PR TITLE
Change and Fix script for Scoop

### DIFF
--- a/PSWinUtil.psd1
+++ b/PSWinUtil.psd1
@@ -12,7 +12,7 @@
     RootModule        = 'PSWinUtil.psm1'
 
     # このモジュールのバージョン番号です。
-    ModuleVersion     = '1.5.4'
+    ModuleVersion     = '1.5.5'
 
     # サポートされている PSEditions
     # CompatiblePSEditions = @()


### PR DESCRIPTION
- Specify the bucket name in addition to the app name when reinstalling a failed app.
- If git installation fails, uninstall it and try installing again
- Try to avoid Scoop updates and try to install in case Git is required to update Scoop
- If the process environment variable SCOOP is not set, set it