### PR TITLE
Changed the behavior when the parameter Unsafe is specified

### DIFF
--- a/PSWinUtil.psd1
+++ b/PSWinUtil.psd1
@@ -12,7 +12,7 @@
     RootModule        = 'PSWinUtil.psm1'
 
     # このモジュールのバージョン番号です。
-    ModuleVersion     = '1.5.5'
+    ModuleVersion     = '1.5.6'
 
     # サポートされている PSEditions
     # CompatiblePSEditions = @()


### PR DESCRIPTION
- Skip hash checking on Scoop and Chocolatey when the parameter Unsafe is specified